### PR TITLE
tokenize()

### DIFF
--- a/pycrest/eve.py
+++ b/pycrest/eve.py
@@ -83,6 +83,16 @@ class EVE(APIConnection):
             raise APIException("Got unexpected status code from API: %i" % res.status_code)
         return AuthedConnection(res.json(), self._authed_endpoint, self._oauth_endpoint, self.client_id, self.api_key)
 
+    def tokenize(self, refresh_token):
+        auth = text_(base64.b64encode(bytes_("%s:%s" % (self.client_id, self.api_key))))
+        headers = {"Authorization": "Basic %s" % auth}
+        params = {"grant_type": "refresh_token", "refresh_token": refresh_token}
+        res = requests.post("%s/token" % self._oauth_endpoint, params=params, headers=headers)
+        if res.status_code != 200:
+            raise APIException("Got unexpected status code from API: %i" % res.status_code)
+        con = AuthedConnection(res.json(), self._authed_endpoint, self._oauth_endpoint, self.client_id, self.api_key)
+        return con.refresh()
+
 
 class AuthedConnection(EVE):
     def __init__(self, res, endpoint, oauth_endpoint, client_id=None, api_key=None, **kwargs):


### PR DESCRIPTION
For creating authed connection from previously saved refresh_token, since refresh_token isn't expiring and could be saved in config or something like that
