### PR TITLE
Use requests.Sessions and allow weak ciphers to connect to public CREST

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.3"
   - "3.4"
   - "pypy"
-install: pip install mako coveralls testtools mock
+install: pip install mako coveralls testtools httmock
 script: coverage run setup.py test
 after_success: coveralls
 notifications:

--- a/pycrest/eve.py
+++ b/pycrest/eve.py
@@ -45,10 +45,10 @@ class APIConnection(object):
 
 class EVE(APIConnection):
     def __init__(self, **kwargs):
-        self.api_key = kwargs.get('api_key', None)
-        self.client_id = kwargs.get('client_id', None)
-        self.redirect_uri = kwargs.get('redirect_uri', None)
-        if kwargs.get('testing', None):
+        self.api_key = kwargs.pop('api_key', None)
+        self.client_id = kwargs.pop('client_id', None)
+        self.redirect_uri = kwargs.pop('redirect_uri', None)
+        if kwargs.pop('testing', False):
             self._public_endpoint = "http://public-crest-sisi.testeveonline.com/"
             self._authed_endpoint = "https://api-sisi.testeveonline.com/"
             self._image_server = "https://image.testeveonline.com/"
@@ -62,8 +62,8 @@ class EVE(APIConnection):
         self._cache = {}
         self._data = None
 
-        APIConnection.__init__(self, user_agent=kwargs.get('user_agent', 'PyCrest - v %s' % version),
-                               cache_time=kwargs.get('cache_time', 600))
+        APIConnection.__init__(self, cache_time=kwargs.pop('cache_time', 600),
+                **kwargs)
 
     def __call__(self):
         if not self._data:

--- a/pycrest/eve.py
+++ b/pycrest/eve.py
@@ -4,6 +4,7 @@ import time
 from pycrest import version
 from pycrest.compat import bytes_, text_
 from pycrest.errors import APIException
+from pycrest.weak_ciphers import WeakCiphersAdapter
 
 try:
     from urllib.parse import quote
@@ -28,6 +29,8 @@ class APIConnection(object):
             "Accept": "application/json",
         })
         session.headers.update(additional_headers)
+        session.mount('https://public-crest.eveonline.com',
+                WeakCiphersAdapter())
         self._session = session
 
     def get(self, resource, params=None):

--- a/pycrest/eve.py
+++ b/pycrest/eve.py
@@ -23,7 +23,7 @@ class APIConnection(object):
         if additional_headers is None:
             additional_headers = {}
         if user_agent is None:
-            user_agent = "PyCrest/{}".format(version)
+            user_agent = "PyCrest/{0}".format(version)
         session.headers.update({
             "User-Agent": user_agent,
             "Accept": "application/json",

--- a/pycrest/weak_ciphers.py
+++ b/pycrest/weak_ciphers.py
@@ -1,0 +1,125 @@
+import datetime
+import ssl
+import sys
+import warnings
+
+from requests.adapters import HTTPAdapter
+from requests.packages import urllib3
+from requests.packages.urllib3.util import ssl_
+
+from requests.packages.urllib3.exceptions import (
+    SystemTimeWarning,
+    SecurityWarning,
+)
+from requests.packages.urllib3.packages.ssl_match_hostname import \
+        match_hostname
+
+
+class WeakCiphersHTTPSConnection(urllib3.connection.VerifiedHTTPSConnection):
+
+    # Python versions >=2.7.9 and >=3.4.1 do not (by default) allow ciphers
+    # with MD5. Unfortunately, the CREST public server _only_ supports
+    # TLS_RSA_WITH_RC4_128_MD5 (as of 5 Jan 2015). The cipher list below is
+    # nearly identical except for allowing that cipher as a last resort (and
+    # excluding export versions of ciphers).
+    DEFAULT_CIPHERS = (
+        'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:'
+        'ECDH+HIGH:DH+HIGH:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+HIGH:'
+        'RSA+3DES:ECDH+RC4:DH+RC4:RSA+RC4:!aNULL:!eNULL:!EXP:-MD5:RSA+RC4+MD5'
+    )
+
+    def __init__(self, host, port, ciphers=None, **kwargs):
+        self.ciphers = ciphers if ciphers is not None else self.DEFAULT_CIPHERS
+        super(WeakCiphersHTTPSConnection, self).__init__(host, port, **kwargs)
+
+    def connect(self):
+        # Yup, copied in VerifiedHTTPSConnection.connect just to change the
+        # default cipher list.
+
+        # Add certificate verification
+        conn = self._new_conn()
+
+        resolved_cert_reqs = ssl_.resolve_cert_reqs(self.cert_reqs)
+        resolved_ssl_version = ssl_.resolve_ssl_version(self.ssl_version)
+
+        hostname = self.host
+        if getattr(self, '_tunnel_host', None):
+            # _tunnel_host was added in Python 2.6.3
+            # (See: http://hg.python.org/cpython/rev/0f57b30a152f)
+
+            self.sock = conn
+            # Calls self._set_hostport(), so self.host is
+            # self._tunnel_host below.
+            self._tunnel()
+            # Mark this connection as not reusable
+            self.auto_open = 0
+
+            # Override the host with the one we're requesting data from.
+            hostname = self._tunnel_host
+
+        is_time_off = datetime.date.today() < urllib3.connection.RECENT_DATE
+        if is_time_off:
+            warnings.warn((
+                'System time is way off (before {0}). This will probably '
+                'lead to SSL verification errors').format(
+                    urllib3.connection.RECENT_DATE),
+                SystemTimeWarning
+            )
+
+        # Wrap socket using verification with the root certs in
+        # trusted_root_certs
+        self.sock = ssl_.ssl_wrap_socket(conn, self.key_file, self.cert_file,
+                                    cert_reqs=resolved_cert_reqs,
+                                    ca_certs=self.ca_certs,
+                                    server_hostname=hostname,
+                                    ssl_version=resolved_ssl_version,
+                                    ciphers=self.ciphers)
+
+        if self.assert_fingerprint:
+            ssl_.assert_fingerprint(self.sock.getpeercert(binary_form=True),
+                               self.assert_fingerprint)
+        elif resolved_cert_reqs != ssl.CERT_NONE \
+                and self.assert_hostname is not False:
+            cert = self.sock.getpeercert()
+            if not cert.get('subjectAltName', ()):
+                warnings.warn((
+                    'Certificate has no `subjectAltName`, falling back to check for a `commonName` for now. '
+                    'This feature is being removed by major browsers and deprecated by RFC 2818. '
+                    '(See https://github.com/shazow/urllib3/issues/497 for details.)'),
+                    SecurityWarning
+                )
+            match_hostname(cert, self.assert_hostname or hostname)
+
+        self.is_verified = (resolved_cert_reqs == ssl.CERT_REQUIRED
+                            or self.assert_fingerprint is not None)
+
+
+class WeakCiphersHTTPSConnectionPool(
+        urllib3.connectionpool.HTTPSConnectionPool):
+
+    ConnectionCls = WeakCiphersHTTPSConnection
+
+
+class WeakCiphersPoolManager(urllib3.poolmanager.PoolManager):
+
+    def _new_pool(self, scheme, host, port):
+        if scheme == 'https':
+            return WeakCiphersHTTPSConnectionPool(host, port,
+                    **(self.connection_pool_kw))
+        return super(WeakCiphersPoolManager, self)._new_pool(scheme, host,
+                port)
+
+
+class WeakCiphersAdapter(HTTPAdapter):
+    """"Transport adapter" that allows us to use TLS_RSA_WITH_RC4_128_MD5."""
+
+    def init_poolmanager(self, connections, maxsize, block=False,
+            **pool_kwargs):
+        # Rewrite of the requests.adapters.HTTPAdapter.init_poolmanager method
+        # to use WeakCiphersPoolManager instead of urllib3's PoolManager
+        self._pool_connections = connections
+        self._pool_maxsize = maxsize
+        self._pool_block = block
+
+        self.poolmanager = WeakCiphersPoolManager(num_pools=connections,
+                maxsize=maxsize, block=block, strict=True, **pool_kwargs)

--- a/pycrest/weak_ciphers.py
+++ b/pycrest/weak_ciphers.py
@@ -15,7 +15,8 @@ from requests.packages.urllib3.packages.ssl_match_hostname import \
         match_hostname
 
 
-class WeakCiphersHTTPSConnection(urllib3.connection.VerifiedHTTPSConnection):
+class WeakCiphersHTTPSConnection(
+        urllib3.connection.VerifiedHTTPSConnection): # pragma: no cover
 
     # Python versions >=2.7.9 and >=3.4.1 do not (by default) allow ciphers
     # with MD5. Unfortunately, the CREST public server _only_ supports

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -137,7 +137,7 @@ class TestApi(unittest.TestCase):
         @httmock.all_requests
         def default_useragent(url, request):
             self.assertEqual(request.headers["User-Agent"],
-                    "PyCrest/{}".format(pycrest.version))
+                    "PyCrest/{0}".format(pycrest.version))
 
         @httmock.all_requests
         def custom_useragent(url, request):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,90 +5,115 @@ from pycrest.compat import bytes_, text_
 from pycrest.errors import APIException
 
 try:
-    from urllib.parse import quote
+    from urllib.parse import quote, parse_qs
 except ImportError:  # pragma: no cover
     from urllib import quote
+    from urlparse import parse_qs
 try:
     import testtools as unittest
 except ImportError:
     import unittest
-import mock
+import httmock
 import pycrest
 
 
+@httmock.urlmatch(scheme="https",
+        netloc=r"(public-)?crest(-tq)?\.eveonline\.com",
+        path=r"^/?$")
+def root_mock(url, request):
+    return {
+        "status_code": 200,
+        "content": {
+            "marketData": {
+                "href": "https://public-crest.eveonline.com/market/prices/",
+            },
+            "incursions": {
+                "href": "https://public-crest.eveonline.com/incursions/",
+            },
+            "status": {"eve": "online"}
+        },
+    }
+
+
+@httmock.urlmatch(scheme="https",
+        netloc=r"(public-)?crest(-tq)?\.eveonline\.com",
+        path=r"^/market/prices/?$")
+def market_mock(url, request):
+    if url.netloc == 'crest-tq.eveonline.com':
+        headers = {
+            "Authorization": "Bearer 123asd",
+        }
+    else:
+        headers = {}
+    body = {
+        "totalCount": 2,
+        "items": [
+            {
+                "avg_price": 100,
+                "type": {
+                    "href": "getPunisher",
+                    "name": "Punisher",
+                    "id": 597
+                }
+            },
+            {
+                "avg_price": 101,
+                "type": {
+                    "href": "getRifter",
+                    "name": "Rifter",
+                    "id": 587
+                }
+            },
+            [
+                "foo",
+                "bar"
+            ],
+            "baz"
+        ]
+    }
+    return {
+        "status_code": 200,
+        "content": body,
+    }
+
+
+@httmock.urlmatch(scheme="https",
+        netloc=r"^login.eveonline.com$",
+        path=r"^/oauth/verify/?$")
+def verify_mock(url, request):
+    return {
+        "status_code": 200,
+        "content": {"CharacterName": "Foobar"},
+    }
+
+
+@httmock.all_requests
+def fallback_mock(url, request):
+    return {
+        "status_code": 404,
+        "body": {},
+    }
+
+
+all_mocks = [root_mock, market_mock, verify_mock, fallback_mock]
+
+
 class TestApi(unittest.TestCase):
-    @mock.patch('requests.get')
-    def test_public_api(self, mock_get):
-        mock_resp = mock.MagicMock(requests.Response)
+    def test_public_api(self):
+        with httmock.HTTMock(*all_mocks):
+            eve = pycrest.EVE()
+            self.assertRaises(AttributeError, eve.__getattr__, 'marketData')
+            eve()
+            self.assertEqual(eve().marketData.href, "https://public-crest.eveonline.com/market/prices/")
+            self.assertEqual(eve.marketData().totalCount, 2)
+            self.assertEqual(eve.marketData().items[0].avg_price, 100)
+            self.assertEqual(eve.marketData().items[2][0], "foo")
+            self.assertEqual(eve.marketData().items[3], "baz")
+            self.assertEqual(eve().status().eve, "online")
+            self.assertRaises(APIException, lambda: eve.incursions())  # Scala's notation would be nice
 
-        def _get(href, *args, **kwargs):
-            if href == "https://public-crest.eveonline.com/":
-                body = {
-                    "marketData": {"href": "getMarketData"},
-                    "incursions": {"href": "getIncursions"},
-                    "status": {"eve": "online"}
-                }
-                res = mock_resp()
-                res.status_code = 200
-                res.json.return_value = body
-                return res
-            elif href == "getMarketData":
-                body = {
-                    "totalCount": 2,
-                    "items": [
-                        {
-                            "avg_price": 100,
-                            "type": {
-                                "href": "getPunisher",
-                                "name": "Punisher",
-                                "id": 597
-                            }
-                        },
-                        {
-                            "avg_price": 101,
-                            "type": {
-                                "href": "getRifter",
-                                "name": "Rifter",
-                                "id": 587
-                            }
-                        },
-                        [
-                            "foo",
-                            "bar"
-                        ],
-                        "baz"
-                    ]
-                }
-                res = mock_resp()
-                res.status_code = 200
-                res.json.return_value = body
-                return res
-            elif href == "getIncursions":
-                body = {}
-                res = mock_resp()
-                res.status_code = 404
-                res.json.return_value = body
-                return res
-            else:
-                res = mock_resp()
-                res.status_code = 404
-                res.json.return_value = {}
-                return res
-
-        mock_get.side_effect = _get
-        eve = pycrest.EVE()
-        self.assertRaises(AttributeError, eve.__getattr__, 'marketData')
-        eve()
-        self.assertEqual(eve().marketData.href, "getMarketData")
-        self.assertEqual(eve.marketData().totalCount, 2)
-        self.assertEqual(eve.marketData().items[0].avg_price, 100)
-        self.assertEqual(eve.marketData().items[2][0], "foo")
-        self.assertEqual(eve.marketData().items[3], "baz")
-        self.assertEqual(eve().status().eve, "online")
-        self.assertRaises(APIException, lambda: eve.incursions())  # Scala's notation would be nice
-
-        testing = pycrest.EVE(testing=True)
-        self.assertEqual(testing._public_endpoint, "http://public-crest-sisi.testeveonline.com/")
+            testing = pycrest.EVE(testing=True)
+            self.assertEqual(testing._public_endpoint, "http://public-crest-sisi.testeveonline.com/")
 
 
 class TestAuthorization(unittest.TestCase):
@@ -98,122 +123,64 @@ class TestAuthorization(unittest.TestCase):
         code = "foobar"
         access_token = "123asd"
         refresh_token = "asd123"
-        mock_resp = mock.MagicMock(requests.Response)
 
-        def _get(href, *args, **kwargs):
-            if href == "https://crest-tq.eveonline.com/":
-                body = {
-                    "marketData": {"href": "getMarketData"}
-                }
-                res = mock_resp()
-                res.status_code = 200
-                res.json.return_value = body
-                return res
-            elif href == "getMarketData":
-                self.assertIn('headers', kwargs)
-                self.assertEqual(kwargs['headers']['Authorization'], "Bearer %s" % access_token)
-                body = {
-                    "totalCount": 2,
-                    "foo": {
-                        "foo": "Bar"
+        @httmock.urlmatch(scheme="https",
+                netloc=r"^login.eveonline.com$",
+                path=r"^/oauth/token/?$",
+                method="POST")
+        def token_mock(url, request):
+            params = parse_qs(url.query)
+            if params['grant_type'][0] == 'authorization_code':
+                auth = text_(base64.b64encode(bytes_("%s:%s" % (client_id, api_key))))
+                self.assertEqual(request.headers['Authorization'], "Basic %s" % auth)
+                if params['code'][0] == code:
+                    body = {
+                        "access_token": access_token,
+                        "refresh_token": refresh_token,
+                        "expires_in": 1200
                     }
-                }
-                res = mock_resp()
-                res.status_code = 200
-                res.json.return_value = body
-                return res
-            elif href == "https://login.eveonline.com/oauth/verify":
-                body = {
-                    "CharacterName": "Foobar"
-                }
-                res = mock_resp()
-                res.status_code = 200
-                res.json.return_value = body
-                return res
-            else:
-                res = mock_resp()
-                res.status_code = 404
-                res.json.return_value = {}
-                return res
+                    return {"status_code": 200, "content": body}
+            elif params['grant_type'][0] == 'refresh_token':
+                auth = text_(base64.b64encode(bytes_("%s:%s" % (client_id, api_key))))
+                self.assertEqual(request.headers['Authorization'], "Basic %s" % auth)
+                if params['refresh_token'][0] == refresh_token:
+                    body = {
+                        "access_token": access_token,
+                        "refresh_token": refresh_token,
+                        "expires_in": 1200
+                    }
+                    return {"status_code": 200, "content": body}
+            return {"status_code": 403, "content": {}}
 
-        def _post(href, *args, **kwargs):
-            if href == "https://login.eveonline.com/oauth/token":
-                self.assertIn('headers', kwargs)
-                if kwargs['params']['grant_type'] == 'authorization_code':
-                    auth = text_(base64.b64encode(bytes_("%s:%s" % (client_id, api_key))))
-                    self.assertEqual(kwargs['headers']['Authorization'], "Basic %s" % auth)
-                    if kwargs['params']['code'] == code:
-                        body = {
-                            "access_token": access_token,
-                            "refresh_token": refresh_token,
-                            "expires_in": 1200
-                        }
-                        res = mock_resp()
-                        res.status_code = 200
-                        res.json.return_value = body
-                        return res
-                    else:
-                        res = mock_resp()
-                        res.status_code = 403
-                        return res
-                elif kwargs['params']['grant_type'] == 'refresh_token':
-                    auth = text_(base64.b64encode(bytes_("%s:%s" % (client_id, api_key))))
-                    self.assertEqual(kwargs['headers']['Authorization'], "Basic %s" % auth)
-                    if kwargs['params']['refresh_token'] == refresh_token:
-                        body = {
-                            "access_token": access_token,
-                            "refresh_token": refresh_token,
-                            "expires_in": 1200
-                        }
-                        res = mock_resp()
-                        res.status_code = 200
-                        res.json.return_value = body
-                        return res
-                    else:
-                        res = mock_resp()
-                        res.status_code = 403
-                        return res
-                else:
-                    res = mock_resp()
-                    res.status_code = 403
-                    res.json.return_value = {}
-                    return res
-            else:
-                res = mock_resp()
-                res.status_code = 404
-                res.json.return_value = {}
-                return res
+        with httmock.HTTMock(token_mock, *all_mocks):
+            eve = pycrest.EVE(api_key=api_key, client_id=client_id, redirect_uri="http://foo.bar")
+            auth_uri = "%s/authorize?response_type=code&redirect_uri=%s&client_id=%s&scope=publicData" % (
+                eve._oauth_endpoint,
+                quote("http://foo.bar", safe=''),
+                client_id,
+            )
+            self.assertEqual(eve.auth_uri(scopes=["publicData"]), auth_uri)
+            con = eve.authorize(code)
+            self.assertRaises(APIException, lambda: eve.authorize("notcode"))
+            r = con.refresh()
 
-        with mock.patch('requests.get', side_effect=_get):
-            with mock.patch('requests.post', side_effect=_post):
-                eve = pycrest.EVE(api_key=api_key, client_id=client_id, redirect_uri="http://foo.bar")
-                auth_uri = "%s/authorize?response_type=code&redirect_uri=%s&client_id=%s&scope=publicData" % (
-                    eve._oauth_endpoint,
-                    quote("http://foo.bar", safe=''),
-                    client_id,
-                )
-                self.assertEqual(eve.auth_uri(scopes=["publicData"]), auth_uri)
-                con = eve.authorize(code)
-                self.assertRaises(APIException, lambda: eve.authorize("notcode"))
-                r = con.refresh()
+            self.assertRaises(AttributeError, con.__getattr__, 'marketData')
+            con()
+            self.assertEqual(con.marketData.href, "https://public-crest.eveonline.com/market/prices/")
+            self.assertEqual(con.marketData().totalCount, 2)
+            self.assertEqual(con.marketData().items[1].type.name, "Rifter")
 
-                self.assertRaises(AttributeError, con.__getattr__, 'marketData')
-                con()
-                self.assertEqual(con.marketData.href, "getMarketData")
-                self.assertEqual(con.marketData().totalCount, 2)
-                self.assertEqual(con.marketData().foo.foo, "Bar")
+            info = con.whoami()
+            self.assertEqual(info['CharacterName'], 'Foobar')
+            info = con.whoami()
+            self.assertEqual(info['CharacterName'], con._cache['whoami']['CharacterName'])
+            info = r.whoami()
+            self.assertEqual(info['CharacterName'], 'Foobar')
 
-                info = con.whoami()
-                self.assertEqual(info['CharacterName'], 'Foobar')
-                info = con.whoami()
-                self.assertEqual(info['CharacterName'], con._cache['whoami']['CharacterName'])
-                info = r.whoami()
-                self.assertEqual(info['CharacterName'], 'Foobar')
+            r.refresh_token = "notright"
+            self.assertRaises(APIException, lambda: r.refresh())
 
-                r.refresh_token = "notright"
-                self.assertRaises(APIException, lambda: r.refresh())
-
-                eve = pycrest.EVE(api_key=api_key, client_id=client_id, cache_time=0)
-                con = eve.authorize(code)
-                self.assertEqual(con().marketData().totalCount, 2)
-                self.assertEqual(con().marketData().totalCount, 2)
+            eve = pycrest.EVE(api_key=api_key, client_id=client_id, cache_time=0)
+            con = eve.authorize(code)
+            self.assertEqual(con().marketData().totalCount, 2)
+            self.assertEqual(con().marketData().totalCount, 2)

--- a/tests/test_weak_ciphers.py
+++ b/tests/test_weak_ciphers.py
@@ -1,0 +1,26 @@
+import requests
+from pycrest.weak_ciphers import WeakCiphersAdapter
+try:
+    import testtools as unittest
+except ImportError:
+    import unittest
+
+
+class TestWeakCiphers(unittest.TestCase):
+
+    def setUp(self):
+        super(TestWeakCiphers, self).setUp()
+        session = requests.Session()
+        session.headers.update({"User-Agent": "PyCrest_Cipher_Testing/0.1"})
+        adapter = WeakCiphersAdapter()
+        session.mount("https://public-crest.eveonline.com", adapter)
+        session.mount("http://example.com", adapter)
+        self.session = session
+
+    def test_public_crest(self):
+        resp = self.session.get("https://public-crest.eveonline.com")
+        self.assertIsNotNone(resp)
+
+    def test_http(self):
+        resp = self.session.get("http://example.com")
+        self.assertIsNotNone(resp)


### PR DESCRIPTION
If using Python >=2.7.9 or >=3.4.1, you'll get an exception when trying to connect to the public CREST server, as it only supports TLS_RSA_WITH_RC4_128_MD5. I tweaked the primary class(es) to use requests.Session so that I could then use a custom [Transport Adapter](http://docs.python-requests.org/en/latest/user/advanced/#transport-adapters) to add that cipher to the allowed list. This also has the added benefit of being able to use some of the more advanced features in Requests.

As part of this, I also rewrote the test suite to use HTTMock, as it makes it a lot easier to mock out responses from Requests.
