### PR TITLE
import urllib3 directly if not in requests

### DIFF
--- a/pycrest/weak_ciphers.py
+++ b/pycrest/weak_ciphers.py
@@ -4,15 +4,29 @@ import sys
 import warnings
 
 from requests.adapters import HTTPAdapter
-from requests.packages import urllib3
-from requests.packages.urllib3.util import ssl_
 
-from requests.packages.urllib3.exceptions import (
-    SystemTimeWarning,
-    SecurityWarning,
-)
-from requests.packages.urllib3.packages.ssl_match_hostname import \
-        match_hostname
+try:
+  from requests.packages import urllib3
+  from requests.packages.urllib3.util import ssl_
+
+  from requests.packages.urllib3.exceptions import (
+      SystemTimeWarning,
+      SecurityWarning,
+  )
+  from requests.packages.urllib3.packages.ssl_match_hostname import \
+          match_hostname
+except:
+  import urllib3
+  from urllib3.util import ssl_
+
+  from urllib3.exceptions import (
+      SystemTimeWarning,
+      SecurityWarning,
+  )
+  from urllib3.packages.ssl_match_hostname import \
+          match_hostname
+
+
 
 
 class WeakCiphersHTTPSConnection(


### PR DESCRIPTION
On debian/ubuntu, requests relies on the system-distributed urllib3 rather than that distributed within requests
