### PR TITLE
Scopes should be space-delineated

### DIFF
--- a/pycrest/eve.py
+++ b/pycrest/eve.py
@@ -210,7 +210,7 @@ class EVE(APIConnection):
             self._oauth_endpoint,
             quote(self.redirect_uri, safe=''),
             self.client_id,
-            "&scope=%s" % ','.join(s) if scopes else '',
+            "&scope=%s" % ' '.join(s) if scopes else '',
             "&state=%s" % state if state else ''
         )
 


### PR DESCRIPTION
Very quick and simple change to fix scopes in auth uri. Comma doesn't work and is not supported, so it's been changed to space-delineated per the CREST docs.
