### PR TITLE
[WIP] Return additional request information

### DIFF
--- a/pycrest/eve.py
+++ b/pycrest/eve.py
@@ -444,8 +444,9 @@ class APIObject(object):
         if item in self._dict:
             return self._dict[item]
 
-        if isinstance(self._dict['result'], APIObject):
-            return self._dict['result'].__getattr__(item)
+        if 'result' in self._dict:
+            if isinstance(self._dict['result'], APIObject):
+                return self._dict['result'].__getattr__(item)
 
         raise AttributeError(item)
 

--- a/pycrest/eve.py
+++ b/pycrest/eve.py
@@ -221,9 +221,10 @@ class APIConnection(object):
                 prms.items()))
         expires = self._get_expires(res)
         response = {'result': ret,
+                    'endpoint_version': res.headers['content-type'].split(';')[0],
                     'status_code': res.status_code,
-                    'expires': expires,
-                    'timestamp': time.time() + expires}
+                    'expires_in': expires,
+                    'expires_at': time.time() + expires}
 
         if expires > 0:
             self.cache.put(

--- a/pycrest/eve.py
+++ b/pycrest/eve.py
@@ -418,6 +418,7 @@ class APIObject(object):
         self._dict = {}
         self.connection = connection
         for k, v in parent.items():
+            # If we don't "pull in" 'result' it will cause the creation of an unwanted APIObject
             if k == 'result':
                 v = parent[k]
             if isinstance(v, dict):

--- a/tests/test_pull_37.py
+++ b/tests/test_pull_37.py
@@ -1,0 +1,63 @@
+'''
+Created on Jun 27, 2016
+
+@author: henk
+'''
+from pycrest.eve import EVE, APIObject
+import httmock
+import unittest
+
+@httmock.urlmatch(
+    scheme="https",
+    netloc=r"(api-sisi\.test)?(crest-tq\.)?eveonline\.com$",
+    path=r"^/?$")
+def root_mock(url, request):
+    return httmock.response(
+        status_code=200,
+        content='''{
+    "marketData": {
+        "href": "https://crest-tq.eveonline.com/market/prices/"
+    }}''', headers={"content-type": "application/vnd.ccp.eve.Api-v5+json; charset=utf-8"})
+
+
+@httmock.urlmatch(
+    scheme="https",
+    netloc=r"(api-sisi\.test)?(crest-tq\.)?eveonline\.com$",
+    path=r"^/market/prices/?$")
+def market_prices_mock(url, request):
+    return httmock.response(
+        status_code=200,
+        content='{"result": "10213", "items": [], "status_code": 500, "pa'
+        'geCount_str": "1", "totalCount": 10213}',
+        headers={"content-type": "application/vnd.ccp.eve.Api-v5+json; charset=utf-8"})
+
+
+all_httmocks = [
+    root_mock,
+    market_prices_mock]
+
+
+class TestEVE(unittest.TestCase):
+
+    def setUp(self):
+        self.api = EVE()
+
+    def test_root(self):
+        with httmock.HTTMock(*all_httmocks):
+            res = self.api()
+            self.assertTrue(isinstance(res, APIObject))
+            self.assertEqual(res.endpoint_version, 'application/vnd.ccp.eve.Api-v5+json')
+            self.assertEqual(res.status_code, 200)
+
+    def test_market_price(self):
+        with httmock.HTTMock(*all_httmocks):
+            res = self.api().marketData()
+            self.assertEqual(res.status_code, 200)
+            self.assertEqual(res.result.status_code, 500)
+            self.assertEqual(res.result.result, '10213')
+
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pull_37.py
+++ b/tests/test_pull_37.py
@@ -17,6 +17,9 @@ def root_mock(url, request):
         content='''{
     "marketData": {
         "href": "https://crest-tq.eveonline.com/market/prices/"
+    },
+    "perverse": {
+        "href": "https://crest-tq.eveonline.com/perverse/"
     }}''', headers={"content-type": "application/vnd.ccp.eve.Api-v5+json; charset=utf-8"})
 
 
@@ -31,10 +34,33 @@ def market_prices_mock(url, request):
         'geCount_str": "1", "totalCount": 10213}',
         headers={"content-type": "application/vnd.ccp.eve.Api-v5+json; charset=utf-8"})
 
+@httmock.urlmatch(
+    scheme="https",
+    netloc=r"(api-sisi\.test)?(crest-tq\.)?eveonline\.com$",
+    path=r"^/perverse/?$")
+def perverse_mock(url, request):
+    return httmock.response(
+        status_code=200,
+        content='''{
+    "result": {
+        "result": "10213",
+        "status_code": 500
+    },
+    "items": [],
+    "status_code": {
+        "result": "10214",
+        "status_code": 501
+    },
+    "pageCount_str": "1",
+    "totalCount": 10213
+}''',
+        headers={"content-type": "application/vnd.ccp.eve.Api-v5+json; charset=utf-8"})
+
 
 all_httmocks = [
     root_mock,
-    market_prices_mock]
+    market_prices_mock,
+    perverse_mock]
 
 
 class TestEVE(unittest.TestCase):
@@ -56,8 +82,19 @@ class TestEVE(unittest.TestCase):
             self.assertEqual(res.result.status_code, 500)
             self.assertEqual(res.result.result, '10213')
 
-
-
+    def test_perverse(self):
+        with httmock.HTTMock(*all_httmocks):
+            res = self.api().perverse()
+            self.assertEqual(res.status_code, 200)
+            self.assertEqual(res.pageCount_str, '1')
+            self.assertEqual(res.result.pageCount_str, '1')
+            self.assertEqual(res.totalCount, 10213)
+            self.assertEqual(res.result.totalCount, 10213)
+            self.assertEqual(res.items, [])
+            self.assertEqual(res.result.items, [])
+            self.assertEqual(res.result.status_code.status_code, 501)
+            self.assertEqual(res.result.status_code.result, '10214')
+            self.assertEqual(res.result.result.result, '10213')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
It's a work in progress but I think a valid solution for retrieving extra data from the CREST request. It can easily be extended with additional fields. This PR is intended to take care of #7 and #18 

I will be adding the API version header we get from CCP so the customer knows which version the output is.

I'm looking if I can find a way to prevent breaking backwards compatibility. Any input is appreciated

``` python
>>> from pycrest import EVE
>>> eve = EVE()
>>> print(eve())
{'result': {'systems': {'href': 'https://crest-tq.eveonline.com/solarsystems/'}, 'marketPrices': {'href': 'https://crest-tq.eveonline.com/market/prices/'}, 'opportunities': {'groups': {'href': 'https://crest-tq.eveonline.com/opportunities/groups/'}, 'tasks': {'href': 'https://crest-tq.eveonline.com/opportunities/tasks/'}}, 'marketTypes': {'href': 'https://crest-tq.eveonline.com/market/types/'}, 'constellations': {'href': 'https://crest-tq.eveonline.com/constellations/'}, 'serverName': 'TRANQUILITY', 'userCount_str': '17252', 'sovereignty': {'structures': {'href': 'https://crest-tq.eveonline.com/sovereignty/structures/'}, 'campaigns': {'href': 'https://crest-tq.eveonline.com/sovereignty/campaigns/'}}, 'races': {'href': 'https://crest-tq.eveonline.com/races/'}, 'itemTypes': {'href': 'https://crest-tq.eveonline.com/inventory/types/'}, 'wars': {'href': 'https://crest-tq.eveonline.com/wars/'}, 'itemGroups': {'href': 'https://crest-tq.eveonline.com/inventory/groups/'}, 'dogma': {'effects': {'href': 'https://crest-tq.eveonline.com/dogma/effects/'}, 'attributes': {'href': 'https://crest-tq.eveonline.com/dogma/attributes/'}}, 'industry': {'facilities': {'href': 'https://crest-tq.eveonline.com/industry/facilities/'}, 'systems': {'href': 'https://crest-tq.eveonline.com/industry/systems/'}}, 'itemCategories': {'href': 'https://crest-tq.eveonline.com/inventory/categories/'}, 'insurancePrices': {'href': 'https://crest-tq.eveonline.com/insuranceprices/'}, 'npcCorporations': {'href': 'https://crest-tq.eveonline.com/corporations/npccorps/'}, 'alliances': {'href': 'https://crest-tq.eveonline.com/alliances/'}, 'decode': {'href': 'https://crest-tq.eveonline.com/decode/'}, 'virtualGoodStore': {'href': 'https://vgs-tq.eveonline.com/'}, 'authEndpoint': {'href': 'https://login-tq.eveonline.com/oauth/token/'}, 'regions': {'href': 'https://crest-tq.eveonline.com/regions/'}, 'incursions': {'href': 'https://crest-tq.eveonline.com/incursions/'}, 'tournaments': {'href': 'https://crest-tq.eveonline.com/tournaments/'}, 'userCount': 17252, 'serverVersion': 'EVE-TRANQUILITY 14.06.1058053.1058052', 'bloodlines': {'href': 'https://crest-tq.eveonline.com/bloodlines/'}, 'corporations': {'href': 'https://crest-tq.eveonline.com/corporations/'}, 'serviceStatus': 'online', 'time': {'href': 'https://crest-tq.eveonline.com/time/'}, 'marketGroups': {'href': 'https://crest-tq.eveonline.com/market/groups/'}}, 'status_code': 200, 'expires': 20, 'timestamp': 1469542514.0203292}
>>> print(eve().time())
{'result': {'time': '2016-07-26T14:15:40'}, 'status_code': 200, 'expires': 10, 'timestamp': 1469542504.050126}
>>> print(eve().time().result)
{'time': '2016-07-26T14:15:40'}
>>> print(eve().time().expires)
10
>>> print(eve().time().status_code)
200
```
