### PR TITLE
Add TransportAdapter parameter to PyCrest

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -160,3 +160,29 @@ u'djsdfjklsdf9sd8f908sdf9sd9f8sd9f8sdf8sp9fd89psdf89spdf89spdf89spdf89p'
 
 >>> eve.refr_authorize(refresh_token)
 <pycrest.eve.AuthedConnection object at 0x7f06e21f48d0>
+
+.. highlight:: none
+
+Prevent PyCrest from using cache
+--------------------------------
+
+**No cache for everything in PyCrest**
+This will disable the cache for everything you will do using PyCrest. No call or response will be stored.
+
+.. highlight:: python
+
+>>> pycrest_no_cache = EVE(cache=None)
+
+.. highlight:: none
+
+**Disable caching on demand**
+You can disable the caching for a specific ``get()`` call you don't want to cache, by simply adding ``caching=False|None`` to the call parameters. 
+For example: 
+
+.. highlight:: python
+
+>>> crest_with_caching = EVE()
+>>> crest_root_not_cached = crest_with_caching(caching=False)
+>>> regions = crest_root.regions(caching=False)
+
+.. highlight:: none

--- a/pycrest/eve.py
+++ b/pycrest/eve.py
@@ -150,7 +150,8 @@ class APIConnection(object):
             additional_headers=None,
             user_agent=None,
             cache_dir=None,
-            cache=DictCache):
+            cache=DictCache,
+            transport_adapter=None):
         # Set up a Requests Session
         session = requests.Session()
         if additional_headers is None:
@@ -158,6 +159,10 @@ class APIConnection(object):
         if user_agent is None:
             user_agent = "PyCrest/{0} +https://github.com/pycrest/PyCrest"\
                 .format(version)
+        if transport_adapter is not None:
+            session.mount('http://', transport_adapter)
+            session.mount('https://', transport_adapter)
+            
         session.headers.update({
             "User-Agent": user_agent,
             "Accept": "application/json",

--- a/pycrest/eve.py
+++ b/pycrest/eve.py
@@ -134,7 +134,8 @@ class APIConnection(object):
             additional_headers=None,
             user_agent=None,
             cache_dir=None,
-            cache=None):
+            cache=None,
+            transport_adapter=None):
         # Set up a Requests Session
         session = requests.Session()
         if additional_headers is None:
@@ -142,6 +143,10 @@ class APIConnection(object):
         if user_agent is None:
             user_agent = "PyCrest/{0} +https://github.com/pycrest/PyCrest"\
                 .format(version)
+        if transport_adapter is not None:
+            session.mount('http://', transport_adapter)
+            session.mount('https://', transport_adapter)
+            
         session.headers.update({
             "User-Agent": user_agent,
             "Accept": "application/json",

--- a/pycrest/eve.py
+++ b/pycrest/eve.py
@@ -159,7 +159,7 @@ class APIConnection(object):
         if user_agent is None:
             user_agent = "PyCrest/{0} +https://github.com/pycrest/PyCrest"\
                 .format(version)
-        if transport_adapter is not None and isinstance(transport_adapter, HTTPAdapter):
+        if isinstance(transport_adapter, HTTPAdapter):
             session.mount('http://', transport_adapter)
             session.mount('https://', transport_adapter)
             

--- a/pycrest/eve.py
+++ b/pycrest/eve.py
@@ -8,7 +8,7 @@ import pickle
 from pycrest import version
 from pycrest.compat import bytes_, text_
 from pycrest.errors import APIException, UnsupportedHTTPMethodException
-
+from requests.adapters import HTTPAdapter
 try:
     from urllib.parse import urlparse, urlunparse, parse_qsl
 except ImportError:  # pragma: no cover
@@ -159,7 +159,7 @@ class APIConnection(object):
         if user_agent is None:
             user_agent = "PyCrest/{0} +https://github.com/pycrest/PyCrest"\
                 .format(version)
-        if transport_adapter is not None:
+        if transport_adapter is not None and isinstance(transport_adapter, HTTPAdapter):
             session.mount('http://', transport_adapter)
             session.mount('https://', transport_adapter)
             

--- a/tests/test_pycrest.py
+++ b/tests/test_pycrest.py
@@ -12,6 +12,7 @@ import mock
 import errno
 from pycrest.errors import APIException, UnsupportedHTTPMethodException
 from requests.models import PreparedRequest
+from requests.adapters import HTTPAdapter
 import unittest
 
 try:
@@ -260,6 +261,22 @@ class TestAPIConnection(unittest.TestCase):
         with httmock.HTTMock(check_custom_headers):
             EVE(additional_headers={'PyCrest-Testing': True})
 
+    def test_custom_transport_adapter(self):
+        """ Check if the transport adapter is the one expected (especially if we set it) """
+        class TestHttpAdapter(HTTPAdapter):
+            def __init__(self, *args, **kwargs):
+                super(TestHttpAdapter, self).__init__(*args, **kwargs)
+                
+        eve = EVE()
+        self.assertTrue(isinstance(eve._session.get_adapter('http://'), HTTPAdapter))
+        self.assertTrue(isinstance(eve._session.get_adapter('https://'), HTTPAdapter))
+        self.assertFalse(isinstance(eve._session.get_adapter('http://'), TestHttpAdapter))
+        self.assertFalse(isinstance(eve._session.get_adapter('https://'), TestHttpAdapter))
+        
+        eve = EVE(transport_adapter=TestHttpAdapter())
+        self.assertTrue(isinstance(eve._session.get_adapter('http://'), TestHttpAdapter))
+        self.assertTrue(isinstance(eve._session.get_adapter('https://'), TestHttpAdapter))
+            
     def test_default_cache(self):
         self.assertTrue(isinstance(self.api.cache, DictCache))
 

--- a/tests/test_pycrest.py
+++ b/tests/test_pycrest.py
@@ -267,6 +267,10 @@ class TestAPIConnection(unittest.TestCase):
             def __init__(self, *args, **kwargs):
                 super(TestHttpAdapter, self).__init__(*args, **kwargs)
                 
+        class FakeHttpAdapter(object):
+            def __init__(self, *args, **kwargs):
+                pass
+                
         eve = EVE()
         self.assertTrue(isinstance(eve._session.get_adapter('http://'), HTTPAdapter))
         self.assertTrue(isinstance(eve._session.get_adapter('https://'), HTTPAdapter))
@@ -276,6 +280,15 @@ class TestAPIConnection(unittest.TestCase):
         eve = EVE(transport_adapter=TestHttpAdapter())
         self.assertTrue(isinstance(eve._session.get_adapter('http://'), TestHttpAdapter))
         self.assertTrue(isinstance(eve._session.get_adapter('https://'), TestHttpAdapter))
+        
+        # check that the wrong httpadapter is not used
+        eve = EVE(transport_adapter=FakeHttpAdapter())
+        self.assertTrue(isinstance(eve._session.get_adapter('http://'), HTTPAdapter))
+        self.assertFalse(isinstance(eve._session.get_adapter('http://'), FakeHttpAdapter))
+        
+        eve = EVE(transport_adapter='')
+        self.assertTrue(isinstance(eve._session.get_adapter('http://'), HTTPAdapter))
+        
             
     def test_default_cache(self):
         self.assertTrue(isinstance(self.api.cache, DictCache))


### PR DESCRIPTION
Add the transport adapter to the EVE class as a constructor parameter, this way, as we discussed in #42, the user will be able to define it the way he need it, or simply use the requests default transport adapter `HTTPAdapter`
